### PR TITLE
Export to Adobe, fuzzy matching, and duplicate page identification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ RUN mkdir -p /home/user/app/output \
 # Copy installed packages from builder stage
 COPY --from=builder /install /usr/local/lib/python3.11/site-packages/
 
+# Download NLTK data packages
+RUN python -m nltk.downloader punkt stopwords punkt_tab
+
 # Entrypoint helps to switch between Gradio and Lambda mode
 COPY entrypoint.sh /entrypoint.sh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,8 @@ boto3==1.35.83
 pyarrow==18.1.0
 openpyxl==3.1.2
 Faker==22.2.0
+python-levenshtein==0.26.1
+spaczz==0.6.1
 gradio_image_annotation==0.2.5
 numpy==1.26.4
 awslambdaric==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ presidio-image-redactor==0.0.53
 pikepdf==8.15.1
 pandas==2.2.3
 nltk==3.9.1
+scikit-learn==1.5.2
 spacy==3.8.3
 #en_core_web_lg @ https://github.com/explosion/spacy-#models/releases/download/en_core_web_lg-3.8.0/en_core_web_sm-#3.8.0.tar.gz
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0.tar.gz

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ presidio_anonymizer==2.2.355
 presidio-image-redactor==0.0.53
 pikepdf==8.15.1
 pandas==2.2.3
+nltk==3.9.1
 spacy==3.8.3
 #en_core_web_lg @ https://github.com/explosion/spacy-#models/releases/download/en_core_web_lg-3.8.0/en_core_web_sm-#3.8.0.tar.gz
 en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0.tar.gz

--- a/tools/custom_image_analyser_engine.py
+++ b/tools/custom_image_analyser_engine.py
@@ -560,7 +560,7 @@ def run_page_text_redaction(
         if not nlp_analyser:
             raise ValueError("nlp_analyser is required for Local identification method")
         
-        print("page text:", page_text)
+        #print("page text:", page_text)
 
         page_analyser_result = nlp_analyser.analyze(
             text=page_text,
@@ -1077,15 +1077,15 @@ class CustomImageAnalyzerEngine:
             line_length = len(line_text)
             redaction_text = redaction_relevant_ocr_result.text
 
-            # print(f"Processing line: '{line_text}'")
+            #print(f"Processing line: '{line_text}'")
             
             for redaction_result in text_analyzer_results:
-                # print(f"Checking redaction result: {redaction_result}")
-                # print("redaction_text:", redaction_text)
-                # print("line_length:", line_length)
-                # print("line_text:", line_text)
+                #print(f"Checking redaction result: {redaction_result}")
+                #print("redaction_text:", redaction_text)
+                #print("line_length:", line_length)
+                #print("line_text:", line_text)
                 
-                # Check if the redaction text is no in the allow list
+                # Check if the redaction text is not in the allow list
                 
                 if redaction_text not in allow_list:
                     
@@ -1098,14 +1098,45 @@ class CustomImageAnalyzerEngine:
                     matched_words = matched_text.split()
                     
                     # print(f"Found match: '{matched_text}' in line")
+
+                    # for word_info in ocr_results_with_children_child_info.get('words', []):
+                    #     # Check if this word is part of our match
+                    #     if any(word.lower() in word_info['text'].lower() for word in matched_words):
+                    #         matching_word_boxes.append(word_info['bounding_box'])
+                    #         print(f"Matched word: {word_info['text']}")
                     
                     # Find the corresponding words in the OCR results
                     matching_word_boxes = []
+                    
+                    #print("ocr_results_with_children_child_info:", ocr_results_with_children_child_info)
+
+                    current_position = 0
+
                     for word_info in ocr_results_with_children_child_info.get('words', []):
-                        # Check if this word is part of our match
-                        if any(word.lower() in word_info['text'].lower() for word in matched_words):
+                        word_text = word_info['text']
+                        word_length = len(word_text)
+
+                        # Assign start and end character positions
+                        #word_info['start_position'] = current_position
+                        #word_info['end_position'] = current_position + word_length
+
+                        word_start = current_position
+                        word_end = current_position + word_length
+
+                        # Update current position for the next word
+                        current_position += word_length + 1  # +1 for the space after the word
+
+                        #print("word_info['bounding_box']:", word_info['bounding_box'])
+                        #print("word_start:", word_start)
+                        #print("start_in_line:", start_in_line)
+
+                        #print("word_end:", word_end)
+                        #print("end_in_line:", end_in_line)
+                        
+                        # Check if the word's bounding box is within the start and end bounds
+                        if word_start >= start_in_line and word_end <= (end_in_line + 1):
                             matching_word_boxes.append(word_info['bounding_box'])
-                            # print(f"Matched word: {word_info['text']}")
+                            #print(f"Matched word: {word_info['text']}")
                     
                     if matching_word_boxes:
                         # Calculate the combined bounding box for all matching words
@@ -1127,7 +1158,7 @@ class CustomImageAnalyzerEngine:
                                 text=matched_text
                             )
                         )
-                        # print(f"Added bounding box for: '{matched_text}'")
+                        #print(f"Added bounding box for: '{matched_text}'")
 
         return redaction_bboxes
     

--- a/tools/data_anonymise.py
+++ b/tools/data_anonymise.py
@@ -12,7 +12,7 @@ from presidio_analyzer import AnalyzerEngine, BatchAnalyzerEngine, DictAnalyzerR
 from presidio_anonymizer import AnonymizerEngine, BatchAnonymizerEngine
 from presidio_anonymizer.entities import OperatorConfig, ConflictResolutionStrategy
 
-from tools.helper_functions import output_folder, get_file_path_end, read_file, detect_file_type
+from tools.helper_functions import output_folder, get_file_name_without_type, read_file, detect_file_type
 from tools.load_spacy_model_custom_recognisers import nlp_analyser, score_threshold
 
 # Use custom version of analyze_dict to be able to track progress
@@ -434,7 +434,7 @@ def anonymise_data_files(file_paths:List[str], in_text:str, anon_strat:str, chos
             file_type = detect_file_type(anon_file)
             print("File type is:", file_type)
 
-            out_file_part = get_file_path_end(anon_file.name)
+            out_file_part = get_file_name_without_type(anon_file.name)
     
             if file_type == 'xlsx':
                 print("Running through all xlsx sheets")
@@ -472,7 +472,7 @@ def anonymise_data_files(file_paths:List[str], in_text:str, anon_strat:str, chos
             else:
                 sheet_name = ""
                 anon_df = read_file(anon_file)
-                out_file_part = get_file_path_end(anon_file.name)
+                out_file_part = get_file_name_without_type(anon_file.name)
                 out_file_paths, out_message, key_string, log_files_output_paths = anon_wrapper_func(anon_file, anon_df, chosen_cols, out_file_paths, out_file_part, out_message, sheet_name, anon_strat, language, chosen_redact_entities, in_allow_list, file_type, "", log_files_output_paths)
 
         # Increase latest file completed count unless we are at the last file

--- a/tools/file_redaction.py
+++ b/tools/file_redaction.py
@@ -27,8 +27,8 @@ from presidio_analyzer import RecognizerResult
 from tools.aws_functions import RUN_AWS_FUNCTIONS
 from tools.custom_image_analyser_engine import CustomImageAnalyzerEngine, OCRResult, combine_ocr_results, CustomImageRecognizerResult, run_page_text_redaction, merge_text_bounding_boxes
 from tools.file_conversion import process_file, image_dpi, convert_review_json_to_pandas_df, redact_whole_pymupdf_page, redact_single_box, convert_pymupdf_to_image_coords
-from tools.load_spacy_model_custom_recognisers import nlp_analyser, score_threshold, custom_entities, custom_recogniser, custom_word_list_recogniser
-from tools.helper_functions import get_file_path_end, output_folder, clean_unicode_text, get_or_create_env_var, tesseract_ocr_option, text_ocr_option, textract_option, local_pii_detector, aws_pii_detector
+from tools.load_spacy_model_custom_recognisers import nlp_analyser, score_threshold, custom_entities, custom_recogniser, custom_word_list_recogniser, CustomWordFuzzyRecognizer
+from tools.helper_functions import get_file_name_without_type, output_folder, clean_unicode_text, get_or_create_env_var, tesseract_ocr_option, text_ocr_option, textract_option, local_pii_detector, aws_pii_detector
 from tools.file_conversion import process_file, is_pdf, is_pdf_or_image
 from tools.aws_textract import analyse_page_with_textract, json_to_ocrresult
 from tools.presidio_analyzer_custom import recognizer_result_from_dict 
@@ -94,6 +94,8 @@ def choose_and_run_redactor(file_paths:List[str],
  page_break_return:bool=False,
  pii_identification_method:str="Local",
  comprehend_query_number:int=0,
+ max_fuzzy_spelling_mistakes_num:int=1,
+ match_fuzzy_whole_phrase_bool:bool=True,
  output_folder:str=output_folder,
  progress=gr.Progress(track_tqdm=True)):
     '''
@@ -127,6 +129,8 @@ def choose_and_run_redactor(file_paths:List[str],
     - page_break_return (bool, optional): A flag indicating if the function should return after a page break. Defaults to False.
     - pii_identification_method (str, optional): The method to redact personal information. Either 'Local' (spacy model), or 'AWS Comprehend' (AWS Comprehend API).
     - comprehend_query_number (int, optional): A counter tracking the number of queries to AWS Comprehend.
+    -  max_fuzzy_spelling_mistakes_num (int, optional): The maximum number of spelling mistakes allowed in a searched phrase for fuzzy matching. Can range from 0-9.
+    -  match_fuzzy_whole_phrase_bool (bool, optional): A boolean where 'True' means that the whole phrase is fuzzy matched, and 'False' means that each word is fuzzy matched separately (excluding stop words).
     - output_folder (str, optional): Output folder for results.
     - progress (gr.Progress, optional): A progress tracker for the redaction process. Defaults to a Progress object with track_tqdm set to True.
 
@@ -279,9 +283,9 @@ def choose_and_run_redactor(file_paths:List[str],
             file_path = file.name    
 
         if file_path:
-            pdf_file_name_without_ext = get_file_path_end(file_path)
+            pdf_file_name_without_ext = get_file_name_without_type(file_path)
             pdf_file_name_with_ext = os.path.basename(file_path)
-            print("Redacting file:", pdf_file_name_with_ext)
+            # print("Redacting file:", pdf_file_name_with_ext)
 
             is_a_pdf = is_pdf(file_path) == True
             if is_a_pdf == False and in_redact_method == text_ocr_option:
@@ -327,7 +331,9 @@ def choose_and_run_redactor(file_paths:List[str],
              comprehend_client,
              textract_client,
              custom_recogniser_word_list,
-             redact_whole_page_list)
+             redact_whole_page_list,
+             max_fuzzy_spelling_mistakes_num,
+             match_fuzzy_whole_phrase_bool)
 
             
             #print("log_files_output_paths at end of image redact function:", log_files_output_paths)
@@ -366,7 +372,9 @@ def choose_and_run_redactor(file_paths:List[str],
             comprehend_query_number,
             comprehend_client,
             custom_recogniser_word_list,
-            redact_whole_page_list)
+            redact_whole_page_list,
+            max_fuzzy_spelling_mistakes_num,
+            match_fuzzy_whole_phrase_bool)
 
         else:
             out_message = "No redaction method selected"
@@ -414,13 +422,7 @@ def choose_and_run_redactor(file_paths:List[str],
 
             # Save the gradio_annotation_boxes to a JSON file
             try:
-                #print("Saving annotations to JSON")
-
-                out_annotation_file_path = out_orig_pdf_file_path + '_review_file.json'
-                with open(out_annotation_file_path, 'w') as f:
-                    json.dump(annotations_all_pages, f)
-                log_files_output_paths.append(out_annotation_file_path)
-
+                
                 #print("Saving annotations to CSV")
 
                 # Convert json to csv and also save this
@@ -434,6 +436,13 @@ def choose_and_run_redactor(file_paths:List[str],
                 out_file_paths.append(out_review_file_path)
 
                 print("Saved review file to csv")
+
+                out_annotation_file_path = out_orig_pdf_file_path + '_review_file.json'
+                with open(out_annotation_file_path, 'w') as f:
+                    json.dump(annotations_all_pages, f)
+                log_files_output_paths.append(out_annotation_file_path)
+
+                print("Saving annotations to JSON")
 
             except Exception as e:
                 print("Could not save annotations to json or csv file:", e)
@@ -694,10 +703,10 @@ def redact_page_with_pymupdf(page:Page, page_annotations:dict, image=None, custo
                 x1 = pymupdf_x1
                 x2 = pymupdf_x2
 
-                # if hasattr(annot, 'text') and annot.text:
-                #     img_annotation_box["text"] = annot.text
-                # else:
-                #     img_annotation_box["text"] = ""
+                if hasattr(annot, 'text') and annot.text:
+                    img_annotation_box["text"] = annot.text
+                else:
+                    img_annotation_box["text"] = ""
 
             # Else should be CustomImageRecognizerResult
             else:
@@ -715,10 +724,11 @@ def redact_page_with_pymupdf(page:Page, page_annotations:dict, image=None, custo
                     img_annotation_box["label"] = annot.entity_type
                 except:
                     img_annotation_box["label"] = "Redaction"
-                # if hasattr(annot, 'text') and annot.text:
-                #     img_annotation_box["text"] = annot.text
-                # else:
-                #     img_annotation_box["text"] = ""
+
+                if hasattr(annot, 'text') and annot.text:
+                    img_annotation_box["text"] = annot.text
+                else:
+                    img_annotation_box["text"] = ""
 
             rect = Rect(x1, pymupdf_y1, x2, pymupdf_y2)  # Create the PyMuPDF Rect
 
@@ -749,12 +759,14 @@ def redact_page_with_pymupdf(page:Page, page_annotations:dict, image=None, custo
 
                 if isinstance(annot, Dictionary):
                     img_annotation_box["label"] = str(annot["/T"])
+
+                    if hasattr(annot, 'Contents'):
+                        img_annotation_box["text"] = annot.Contents
+                    else:
+                        img_annotation_box["text"] = ""
                 else:
                     img_annotation_box["label"] = "REDACTION"
-                # if hasattr(annot, 'text') and annot.text:
-                #     img_annotation_box["text"] = annot.text
-                # else:
-                #     img_annotation_box["text"] = ""
+                    img_annotation_box["text"] = ""                
 
         # Convert to a PyMuPDF Rect object
         #rect = Rect(rect_coordinates)
@@ -913,6 +925,8 @@ def redact_image_pdf(file_path:str,
                      textract_client:str="",
                      custom_recogniser_word_list:List[str]=[],
                      redact_whole_page_list:List[str]=[],
+                     max_fuzzy_spelling_mistakes_num:int=1,
+                     match_fuzzy_whole_phrase_bool:bool=True,
                      page_break_val:int=int(page_break_value),
                      log_files_output_paths:List=[],
                      max_time:int=int(max_time_value),                                       
@@ -945,14 +959,16 @@ def redact_image_pdf(file_path:str,
     - textract_client (optional): A connection to the AWS Textract service via the boto3 package.
     - custom_recogniser_word_list (optional): A list of custom words that the user has chosen specifically to redact.
     - redact_whole_page_list (optional, List[str]): A list of pages to fully redact.
+    - max_fuzzy_spelling_mistakes_num (int, optional): The maximum number of spelling mistakes allowed in a searched phrase for fuzzy matching. Can range from 0-9.
+    - match_fuzzy_whole_phrase_bool (bool, optional): A boolean where 'True' means that the whole phrase is fuzzy matched, and 'False' means that each word is fuzzy matched separately (excluding stop words).
     - page_break_val (int, optional): The value at which to trigger a page break. Defaults to 3.
     - log_files_output_paths (List, optional): List of file paths used for saving redaction process logging results.
     - max_time (int, optional): The maximum amount of time (s) that the function should be running before it breaks. To avoid timeout errors with some APIs.      
     - progress (Progress, optional): A progress tracker for the redaction process. Defaults to a Progress object with track_tqdm set to True.
 
-    The function returns a fully or partially-redacted PDF document.
+    The function returns a redacted PDF document along with processing output objects.
     '''
-    file_name = get_file_path_end(file_path)
+    file_name = get_file_name_without_type(file_path)
     fill = (0, 0, 0)   # Fill colour for redactions
     comprehend_query_number_new = 0
 
@@ -962,11 +978,14 @@ def redact_image_pdf(file_path:str,
         nlp_analyser.registry.remove_recognizer("CUSTOM")
         new_custom_recogniser = custom_word_list_recogniser(custom_recogniser_word_list)
         #print("new_custom_recogniser:", new_custom_recogniser)
-        nlp_analyser.registry.add_recognizer(new_custom_recogniser)      
+        nlp_analyser.registry.add_recognizer(new_custom_recogniser)
 
+        nlp_analyser.registry.remove_recognizer("CUSTOM_FUZZY")
+        new_custom_fuzzy_recogniser = CustomWordFuzzyRecognizer(supported_entities=["CUSTOM_FUZZY"], custom_list=custom_recogniser_word_list, spelling_mistakes_max=max_fuzzy_spelling_mistakes_num, search_whole_phrase=match_fuzzy_whole_phrase_bool)
+        #print("new_custom_recogniser:", new_custom_recogniser)
+        nlp_analyser.registry.add_recognizer(new_custom_fuzzy_recogniser)
 
-    image_analyser = CustomImageAnalyzerEngine(nlp_analyser)
-    
+    image_analyser = CustomImageAnalyzerEngine(nlp_analyser)    
 
     if pii_identification_method == "AWS Comprehend" and comprehend_client == "":
         print("Connection to AWS Comprehend service unsuccessful.")
@@ -1190,6 +1209,7 @@ def redact_image_pdf(file_path:str,
 
             ## Apply annotations with pymupdf            
             else:
+                print("merged_redaction_boxes:", merged_redaction_bboxes)
                 #print("redact_whole_page_list:", redact_whole_page_list)
                 if redact_whole_page_list:
                     int_reported_page_number = int(reported_page_number) 
@@ -1471,6 +1491,8 @@ def create_text_redaction_process_results(analyser_results, analysed_bounding_bo
 def create_pikepdf_annotations_for_bounding_boxes(analysed_bounding_boxes):
     pikepdf_annotations_on_page = []
     for analysed_bounding_box in analysed_bounding_boxes:
+        #print("analysed_bounding_box:", analysed_bounding_boxes)
+
         bounding_box = analysed_bounding_box["boundingBox"]
         annotation = Dictionary(
             Type=Name.Annot,
@@ -1482,6 +1504,7 @@ def create_pikepdf_annotations_for_bounding_boxes(analysed_bounding_boxes):
             IC=[0, 0, 0],
             CA=1, # Transparency
             T=analysed_bounding_box["result"].entity_type,
+            Contents=analysed_bounding_box["text"],
             BS=Dictionary(
                 W=0,                     # Border width: 1 point
                 S=Name.S                # Border style: solid
@@ -1511,6 +1534,8 @@ def redact_text_pdf(
     comprehend_client="",
     custom_recogniser_word_list:List[str]=[],
     redact_whole_page_list:List[str]=[],
+    max_fuzzy_spelling_mistakes_num:int=1,
+    match_fuzzy_whole_phrase_bool:bool=True,
     page_break_val: int = int(page_break_value),  # Value for page break
     max_time: int = int(max_time_value),    
     progress: Progress = Progress(track_tqdm=True)  # Progress tracking object
@@ -1540,6 +1565,8 @@ def redact_text_pdf(
     - comprehend_client (optional): A connection to the AWS Comprehend service via the boto3 package.
     - custom_recogniser_word_list (optional, List[str]): A list of custom words that the user has chosen specifically to redact.
     - redact_whole_page_list (optional, List[str]): A list of pages to fully redact.
+    -  max_fuzzy_spelling_mistakes_num (int, optional): The maximum number of spelling mistakes allowed in a searched phrase for fuzzy matching. Can range from 0-9.
+    -  match_fuzzy_whole_phrase_bool (bool, optional): A boolean where 'True' means that the whole phrase is fuzzy matched, and 'False' means that each word is fuzzy matched separately (excluding stop words).
     - page_break_val: Value for page break
     - max_time (int, optional): The maximum amount of time (s) that the function should be running before it breaks. To avoid timeout errors with some APIs.     
     - progress: Progress tracking object
@@ -1555,8 +1582,11 @@ def redact_text_pdf(
     if custom_recogniser_word_list:        
         nlp_analyser.registry.remove_recognizer("CUSTOM")
         new_custom_recogniser = custom_word_list_recogniser(custom_recogniser_word_list)
-        #print("new_custom_recogniser:", new_custom_recogniser)
         nlp_analyser.registry.add_recognizer(new_custom_recogniser)
+
+        nlp_analyser.registry.remove_recognizer("CUSTOM_FUZZY")
+        new_custom_fuzzy_recogniser = CustomWordFuzzyRecognizer(supported_entities=["CUSTOM_FUZZY"], custom_list=custom_recogniser_word_list, spelling_mistakes_max=max_fuzzy_spelling_mistakes_num, search_whole_phrase=match_fuzzy_whole_phrase_bool)
+        nlp_analyser.registry.add_recognizer(new_custom_fuzzy_recogniser)
 
         # List all elements currently in the nlp_analyser registry
         #print("Current recognizers in nlp_analyser registry:")
@@ -1660,7 +1690,7 @@ def redact_text_pdf(
                                                             language,
                                                             chosen_redact_entities,
                                                             chosen_redact_comprehend_entities,
-                                                            all_line_level_text_results_list, #line_level_text_results_list,
+                                                            all_line_level_text_results_list,
                                                             all_line_characters,
                                                             page_analyser_results,
                                                             page_analysed_bounding_boxes,
@@ -1672,7 +1702,6 @@ def redact_text_pdf(
                                                             custom_entities,
                                                             comprehend_query_number
                                                             )
-
 
                     #print("page_analyser_results:", page_analyser_results)
                     #print("page_analysed_bounding_boxes:", page_analysed_bounding_boxes)
@@ -1688,7 +1717,7 @@ def redact_text_pdf(
                 # Annotate redactions on page
                 pikepdf_annotations_on_page = create_pikepdf_annotations_for_bounding_boxes(page_analysed_bounding_boxes)
 
-                #print("pikepdf_annotations_on_page:", pikepdf_annotations_on_page)
+                # print("pikepdf_annotations_on_page:", pikepdf_annotations_on_page)
 
                 # Make pymupdf page redactions
                 #print("redact_whole_page_list:", redact_whole_page_list)

--- a/tools/find_duplicate_pages.py
+++ b/tools/find_duplicate_pages.py
@@ -1,0 +1,274 @@
+import pandas as pd
+import argparse
+import glob
+import os
+import re
+from tools.helper_functions import output_folder
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+import nltk
+from nltk.corpus import stopwords
+from nltk.tokenize import word_tokenize
+from nltk.stem import PorterStemmer
+import numpy as np
+import random
+import string
+from typing import List
+
+nltk.download('punkt')
+nltk.download('stopwords')
+nltk.download('punkt_tab')
+
+similarity_threshold = 0.9
+
+stop_words = set(stopwords.words('english'))
+# List of words to remove from the stopword set
+#words_to_remove = ['no', 'nor', 'not', 'don', 'don't', 'wasn', 'wasn't', 'weren', 'weren't', "don't", "wasn't", "weren't"]
+
+# Remove the specified words from the stopwords set
+#for word in words_to_remove:
+#    stop_words.discard(word.lower())
+    
+stemmer = PorterStemmer()
+vectorizer = TfidfVectorizer()
+
+def combine_ocr_output_text(input_files):
+    """
+    Combines text from multiple CSV files containing page and text columns.
+    Groups text by file and page number, concatenating text within these groups.
+    
+    Args:
+        input_files (list): List of paths to CSV files
+    
+    Returns:
+        pd.DataFrame: Combined dataframe with columns [file, page, text]
+    """
+    all_data = []
+    output_files = []
+
+    if isinstance(input_files, str):
+        file_paths_list = [input_files]
+    else:
+        file_paths_list = input_files
+    
+    for file in file_paths_list:
+
+        if isinstance(file, str):
+            file_path = file
+        else:
+            file_path = file.name
+
+        # Read CSV file
+        df = pd.read_csv(file_path)
+        
+        # Ensure required columns exist
+        if 'page' not in df.columns or 'text' not in df.columns:
+            print(f"Warning: Skipping {file_path} - missing required columns 'page' and 'text'")
+            continue
+        
+        # Group by page and concatenate text
+        grouped = df.groupby('page')['text'].apply(' '.join).reset_index()
+        
+        # Add filename column
+        grouped['file'] = os.path.basename(file_path)
+        
+        all_data.append(grouped)
+    
+    if not all_data:
+        raise ValueError("No valid CSV files were processed")
+    
+    # Combine all dataframes
+    combined_df = pd.concat(all_data, ignore_index=True)
+    
+    # Reorder columns
+    combined_df = combined_df[['file', 'page', 'text']]
+
+    output_combined_file_path = output_folder + "combined_ocr_output_files.csv"
+    combined_df.to_csv(output_combined_file_path, index=None)
+
+    output_files.append(output_combined_file_path)
+    
+    return combined_df, output_files
+
+def process_data(df, column:str):
+    '''
+    Clean and stem text columns in a data frame
+    '''
+    
+    def _clean_text(raw_text):
+        # Remove HTML tags
+        clean = re.sub(r'<.*?>', '', raw_text)
+        clean = re.sub(r'&nbsp;', ' ', clean)
+        clean = re.sub(r'\r\n', ' ', clean)
+        clean = re.sub(r'&lt;', ' ', clean)
+        clean = re.sub(r'&gt;', ' ', clean)
+        clean = re.sub(r'<strong>', ' ', clean)
+        clean = re.sub(r'</strong>', ' ', clean)
+
+        # Replace non-breaking space \xa0 with a space
+        clean = clean.replace(u'\xa0', u' ')
+        # Remove extra whitespace
+        clean = ' '.join(clean.split())
+
+        # Tokenize the text
+        words = word_tokenize(clean.lower())
+
+        # Remove punctuation and numbers
+        words = [word for word in words if word.isalpha()]
+
+        # Remove stopwords
+        words = [word for word in words if word not in stop_words]
+
+        # Join the cleaned words back into a string
+        return ' '.join(words)
+
+    # Function to apply stemming
+    def _apply_stemming(text):
+        # Tokenize the text
+        words = word_tokenize(text.lower())
+        
+        # Apply stemming to each word
+        stemmed_words = [stemmer.stem(word) for word in words]
+        
+        # Join the stemmed words back into a single string
+        return ' '.join(stemmed_words)
+
+
+
+
+    df['text_clean'] = df[column].apply(_clean_text)
+    df['text_clean'] = df['text_clean'].apply(_apply_stemming)
+    
+    return df
+
+def identify_similar_pages(input_files:List[str]):
+
+    output_paths = []
+
+    df, output_files = combine_ocr_output_text(input_files)
+
+    output_paths.extend(output_files)
+
+    # Clean text
+    df = process_data(df, 'text')
+
+    # Vectorise text
+    tfidf_matrix = vectorizer.fit_transform(df['text_clean'])
+
+    # Calculate cosine similarity
+    similarity_matrix = cosine_similarity(tfidf_matrix)
+
+    # Find the indices of the most similar pages
+    np.fill_diagonal(similarity_matrix, 0)  # Ignore self-comparisons
+    similar_pages = np.argwhere(similarity_matrix > similarity_threshold)  # Threshold of similarity
+
+    #print(similar_pages)
+
+    # Create a DataFrame for similar pairs and their scores
+    similarity_df = pd.DataFrame({
+        'Page1_Index': similar_pages[:, 0],
+        'Page2_Index': similar_pages[:, 1],
+        'Page1_File': similar_pages[:, 0],
+        'Page2_File': similar_pages[:, 1],
+        'Similarity_Score': similarity_matrix[similar_pages[:, 0], similar_pages[:, 1]]
+    })
+
+    # Filter out duplicate pairs (keep only one direction)
+    similarity_df = similarity_df[similarity_df['Page1_Index'] < similarity_df['Page2_Index']]
+
+    # Map the indices to their corresponding text and metadata
+    similarity_df['Page1_File'] = similarity_df['Page1_File'].map(df['file'])
+    similarity_df['Page2_File'] = similarity_df['Page2_File'].map(df['file'])
+
+    similarity_df['Page1_Page'] = similarity_df['Page1_Index'].map(df['page'])
+    similarity_df['Page2_Page'] = similarity_df['Page2_Index'].map(df['page'])
+
+    similarity_df['Page1_Text'] = similarity_df['Page1_Index'].map(df['text'])
+    similarity_df['Page2_Text'] = similarity_df['Page2_Index'].map(df['text'])
+
+    similarity_df_out = similarity_df[['Page1_File', 'Page1_Page', 'Page2_File', 'Page2_Page', 'Similarity_Score', 'Page1_Text', 'Page2_Text']]
+    similarity_df_out = similarity_df_out.sort_values(["Page1_File", "Page1_Page", "Page2_File", "Page2_Page", "Similarity_Score"], ascending=[True, True, True, True, False])
+
+    # Save detailed results to a CSV file
+    similarity_file_output_path = output_folder + 'page_similarity_results.csv'
+    similarity_df_out.to_csv(similarity_file_output_path, index=False)
+
+    output_paths.append(similarity_file_output_path)
+
+    if not similarity_df_out.empty:
+        unique_files = similarity_df_out['Page2_File'].unique()
+        for redact_file in unique_files:
+            output_file_name = output_folder + redact_file + "_whole_page.csv"
+            whole_pages_to_redact_df = similarity_df_out.loc[similarity_df_out['Page2_File']==redact_file,:][['Page2_Page']]
+            whole_pages_to_redact_df.to_csv(output_file_name, header=None, index=None)
+
+            output_paths.append(output_file_name)            
+
+
+    return similarity_df_out, output_paths
+
+# Perturb text
+# Apply the perturbation function with a 10% error probability
+def perturb_text_with_errors(series):
+
+    def _perturb_text(text, error_probability=0.1):
+        words = text.split()  # Split text into words
+        perturbed_words = []
+        
+        for word in words:
+            if random.random() < error_probability:  # Add a random error
+                perturbation_type = random.choice(['char_error', 'extra_space', 'extra_punctuation'])
+                
+                if perturbation_type == 'char_error':  # Introduce a character error
+                    idx = random.randint(0, len(word) - 1)
+                    char = random.choice(string.ascii_lowercase)  # Add a random letter
+                    word = word[:idx] + char + word[idx:]
+                
+                elif perturbation_type == 'extra_space':  # Add extra space around a word
+                    word = ' ' + word + ' '
+                
+                elif perturbation_type == 'extra_punctuation':  # Add punctuation to the word
+                    punctuation = random.choice(string.punctuation)
+                    idx = random.randint(0, len(word))  # Insert punctuation randomly
+                    word = word[:idx] + punctuation + word[idx:]
+            
+            perturbed_words.append(word)
+        
+        return ' '.join(perturbed_words)
+
+    series = series.apply(lambda x: _perturb_text(x, error_probability=0.1))
+
+    return series
+
+# Run through command line
+# def main():
+#     parser = argparse.ArgumentParser(description='Combine text from multiple CSV files by page')
+#     parser.add_argument('input_pattern', help='Input file pattern (e.g., "input/*.csv")')
+#     parser.add_argument('--output', '-o', default='combined_text.csv', 
+#                        help='Output CSV file path (default: combined_text.csv)')
+
+#     args = parser.parse_args()
+    
+#     # Get list of input files
+#     input_files = glob.glob(args.input_pattern)
+    
+#     if not input_files:
+#         print(f"No files found matching pattern: {args.input_pattern}")
+#         return
+    
+#     print(f"Processing {len(input_files)} files...")
+    
+#     try:
+#         # Combine the text from all files
+#         combined_df = combine_ocr_output_text(input_files)
+        
+#         # Save to CSV
+#         combined_df.to_csv(args.output, index=False)
+#         print(f"Successfully created combined output: {args.output}")
+#         print(f"Total pages processed: {len(combined_df)}")
+        
+#     except Exception as e:
+#         print(f"Error processing files: {str(e)}")
+
+# if __name__ == "__main__":
+#     main()

--- a/tools/helper_functions.py
+++ b/tools/helper_functions.py
@@ -22,6 +22,9 @@ def reset_state_vars():
             interactive=False
         ), [], [], [], pd.DataFrame(), pd.DataFrame()
 
+def reset_review_vars():
+    return [], pd.DataFrame(), pd.DataFrame()
+
 def get_or_create_env_var(var_name, default_value):
     # Get the environment variable if it exists
     value = os.environ.get(var_name)
@@ -81,6 +84,8 @@ def detect_file_type(filename):
         return 'jpeg'
     elif filename.endswith('.png'):
         return 'png'
+    elif filename.endswith('.xfdf'):
+        return 'xfdf'
     else:
         raise ValueError("Unsupported file type.")
 

--- a/tools/helper_functions.py
+++ b/tools/helper_functions.py
@@ -20,7 +20,7 @@ def reset_state_vars():
             show_share_button=False,
             show_remove_button=False,
             interactive=False
-        ), [], []
+        ), [], [], [], pd.DataFrame(), pd.DataFrame()
 
 def get_or_create_env_var(var_name, default_value):
     # Get the environment variable if it exists

--- a/tools/load_spacy_model_custom_recognisers.py
+++ b/tools/load_spacy_model_custom_recognisers.py
@@ -3,9 +3,13 @@ from typing import List
 from presidio_analyzer import AnalyzerEngine, PatternRecognizer, EntityRecognizer, Pattern, RecognizerResult
 from presidio_analyzer.nlp_engine import SpacyNlpEngine, NlpArtifacts
 import spacy
+from spacy.matcher import Matcher, PhraseMatcher
+from spaczz.matcher import FuzzyMatcher
 spacy.prefer_gpu()
 from spacy.cli.download import download
+import Levenshtein
 import re
+import gradio as gr
 
 model_name = "en_core_web_sm" #"en_core_web_trf"
 score_threshold = 0.001
@@ -65,16 +69,8 @@ ukpostcode_pattern = Pattern(
 # Define the recognizer with one or more patterns
 ukpostcode_recogniser = PatternRecognizer(supported_entity="UKPOSTCODE", name = "UKPOSTCODE", patterns = [ukpostcode_pattern])
 
-# %%
-# Examples for testing
+### Street name
 
-#text = "I live in 510 Broad st SE5 9NG ."
-
-#numbers_result = ukpostcode_recogniser.analyze(text=text, entities=["UKPOSTCODE"])
-#print("Result:")
-#print(numbers_result)
-
-# %%
 def extract_street_name(text:str) -> str:
     """
     Extracts the street name and preceding word (that should contain at least one number) from the given text.
@@ -101,7 +97,7 @@ def extract_street_name(text:str) -> str:
     pattern += rf'(?P<street_name>\w+\s*\b(?:{street_types_pattern})\b)'
 
     # Find all matches in text
-    matches = re.finditer(pattern, text, re.IGNORECASE)
+    matches = re.finditer(pattern, text, re.DOTALL | re.MULTILINE | re.IGNORECASE)
 
     start_positions = []
     end_positions = []
@@ -120,19 +116,6 @@ def extract_street_name(text:str) -> str:
 
     return start_positions, end_positions
 
-
-# %%
-# Some examples for testing
-
-#text = "1234 Main Street, 5678 Oak Rd, 9ABC Elm Blvd, 42 Eagle st."
-#text = "Roberto lives in Five 10 Broad st in Oregon"
-#text = "Roberto lives in 55 Oregon Square"
-#text = "There is 51a no way I will do that"
-#text = "I am writing to apply for"
-
-#extract_street_name(text)
-
-# %%
 class StreetNameRecognizer(EntityRecognizer):
 
     def load(self) -> None:
@@ -163,13 +146,180 @@ class StreetNameRecognizer(EntityRecognizer):
     
 street_recogniser = StreetNameRecognizer(supported_entities=["STREETNAME"])
 
+## Custom fuzzy match recogniser for list of strings
+def custom_fuzzy_word_list_regex(text:str, custom_list:List[str]=[]):
+    # Create regex pattern, handling quotes carefully
+
+    quote_str = '"'
+    replace_str = '(?:"|"|")'
+
+    custom_regex_pattern = '|'.join(
+        rf'(?<!\w){re.escape(term.strip()).replace(quote_str, replace_str)}(?!\w)'
+        for term in custom_list
+    )
+
+    # Find all matches in text
+    matches = re.finditer(custom_regex_pattern, text, re.DOTALL | re.MULTILINE | re.IGNORECASE)
+
+    start_positions = []
+    end_positions = []
+
+    for match in matches:
+        start_pos = match.start()
+        end_pos = match.end()
+
+        start_positions.append(start_pos)
+        end_positions.append(end_pos)
+
+    return start_positions, end_positions
+
+def spacy_fuzzy_search(text: str, custom_query_list:List[str]=[], spelling_mistakes_max:int = 1, search_whole_phrase:bool=True, nlp=nlp, progress=gr.Progress(track_tqdm=True)):
+    ''' Conduct fuzzy match on a list of text data.'''
+
+    all_matches = []
+    all_start_positions = []
+    all_end_positions = []
+    all_ratios = []
+
+    #print("custom_query_list:", custom_query_list)
+
+    if not text:
+        out_message = "Prepared data not found. Have you clicked 'Load data' above to prepare a search index?"
+        print(out_message)
+        return out_message, None  
+
+    for string_query in custom_query_list:
+
+        #print("text:", text)
+        #print("string_query:", string_query)
+
+        query = nlp(string_query)
+
+        if search_whole_phrase == False:
+            # Keep only words that are not stop words
+            token_query = [token.text for token in query if not token.is_space and not token.is_stop and not token.is_punct]
+
+            spelling_mistakes_fuzzy_pattern = "FUZZY" + str(spelling_mistakes_max)
+
+            #print("token_query:", token_query)
+
+            if len(token_query) > 1:
+                #pattern_lemma = [{"LEMMA": {"IN": query}}]
+                pattern_fuzz = [{"TEXT": {spelling_mistakes_fuzzy_pattern: {"IN": token_query}}}]
+            else:
+                #pattern_lemma = [{"LEMMA": query[0]}]
+                pattern_fuzz = [{"TEXT": {spelling_mistakes_fuzzy_pattern: token_query[0]}}]
+
+            matcher = Matcher(nlp.vocab)        
+            matcher.add(string_query, [pattern_fuzz])
+            #matcher.add(string_query, [pattern_lemma])
+        
+        else:
+            # If matching a whole phrase, use Spacy PhraseMatcher, then consider similarity after using Levenshtein distance.
+            #tokenised_query = [string_query.lower()]
+            # If you want to match the whole phrase, use phrase matcher
+            matcher = FuzzyMatcher(nlp.vocab)
+            patterns = [nlp.make_doc(string_query)]  # Convert query into a Doc object
+            matcher.add("PHRASE", patterns, [{"ignore_case": True}])
+
+        batch_size = 256
+        docs = nlp.pipe([text], batch_size=batch_size)
+
+        # Get number of matches per doc
+        for doc in docs: #progress.tqdm(docs, desc = "Searching text", unit = "rows"):
+            matches = matcher(doc)
+            match_count = len(matches)
+
+            # If considering each sub term individually, append match. If considering together, consider weight of the relevance to that of the whole phrase.
+            if search_whole_phrase==False:
+                all_matches.append(match_count)
+
+                for match_id, start, end in matches:
+                    span = str(doc[start:end]).strip()
+                    query_search = str(query).strip()
+                    #print("doc:", doc)
+                    #print("span:", span)
+                    #print("query_search:", query_search)
+                    
+                    # Convert word positions to character positions
+                    start_char = doc[start].idx  # Start character position
+                    end_char = doc[end - 1].idx + len(doc[end - 1])  # End character position
+
+                    # The positions here are word position, not character position
+                    all_matches.append(match_count)
+                    all_start_positions.append(start_char)
+                    all_end_positions.append(end_char)
+                
+            else:
+                for match_id, start, end, ratio, pattern in matches:
+                    span = str(doc[start:end]).strip()
+                    query_search = str(query).strip()
+                    print("doc:", doc)
+                    print("span:", span)
+                    print("query_search:", query_search)
+                    
+                    # Calculate Levenshtein distance. Only keep matches with less than specified number of spelling mistakes
+                    distance = Levenshtein.distance(query_search.lower(), span.lower())
+
+                    print("Levenshtein distance:", distance)
+                    
+                    if distance > spelling_mistakes_max:                                       
+                        match_count = match_count - 1
+                    else:
+                        # Convert word positions to character positions
+                        start_char = doc[start].idx  # Start character position
+                        end_char = doc[end - 1].idx + len(doc[end - 1])  # End character position
+
+                        print("start_char:", start_char)
+                        print("end_char:", end_char)
+
+                        all_matches.append(match_count)
+                        all_start_positions.append(start_char)
+                        all_end_positions.append(end_char)
+                        all_ratios.append(ratio)                        
+
+
+    return all_start_positions, all_end_positions
+
+
+class CustomWordFuzzyRecognizer(EntityRecognizer):
+    def __init__(self, supported_entities: List[str], custom_list: List[str] = [], spelling_mistakes_max: int = 1, search_whole_phrase: bool = True):
+        super().__init__(supported_entities=supported_entities)
+        self.custom_list = custom_list  # Store the custom_list as an instance attribute
+        self.spelling_mistakes_max = spelling_mistakes_max  # Store the max spelling mistakes
+        self.search_whole_phrase = search_whole_phrase  # Store the search whole phrase flag
+
+    def load(self) -> None:
+        """No loading is required."""
+        pass
+
+    def analyze(self, text: str, entities: List[str], nlp_artifacts: NlpArtifacts) -> List[RecognizerResult]:
+        """
+        Logic for detecting a specific PII
+        """
+        start_pos, end_pos = spacy_fuzzy_search(text, self.custom_list, self.spelling_mistakes_max, self.search_whole_phrase)  # Pass new parameters
+
+        results = []
+
+        for i in range(0, len(start_pos)):
+            result = RecognizerResult(
+                entity_type="CUSTOM_FUZZY",
+                start=start_pos[i],
+                end=end_pos[i],
+                score=1
+            )
+            results.append(result)
+
+        return results
+    
+custom_list_default = []
+custom_word_fuzzy_recognizer = CustomWordFuzzyRecognizer(supported_entities=["CUSTOM_FUZZY"], custom_list=custom_list_default)
+
 # Create a class inheriting from SpacyNlpEngine
 class LoadedSpacyNlpEngine(SpacyNlpEngine):
     def __init__(self, loaded_spacy_model):
         super().__init__()
         self.nlp = {"en": loaded_spacy_model}
-
-
 
 # Pass the loaded model to the new LoadedSpacyNlpEngine
 loaded_nlp_engine = LoadedSpacyNlpEngine(loaded_spacy_model = nlp)
@@ -186,4 +336,5 @@ nlp_analyser.registry.add_recognizer(street_recogniser)
 nlp_analyser.registry.add_recognizer(ukpostcode_recogniser)
 nlp_analyser.registry.add_recognizer(titles_recogniser)
 nlp_analyser.registry.add_recognizer(custom_recogniser)
+nlp_analyser.registry.add_recognizer(custom_word_fuzzy_recognizer)
 


### PR DESCRIPTION
Several updates, including:

- Added capabilities to export to and import from Adobe .xfdf files.
- Fuzzy match implementation for deny list. Added option to merge multiple review files.
- Added tab to be able to compare pages across multiple documents and redact duplicates.
- Multiple review files can now be merged together on the redaction settings page