### PR TITLE
Adjust character height overlap and optimize Docker compose files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,5 +46,5 @@ test/usage/*
 model_cache/*
 sanitized_file/*
 src/doc_redaction.egg-info/*
-docker-compose_llama_long_context_dual_gpu.yml
-skills/Example agent skills use prompt local.txt
+docker_compose/*
+skills/example_prompts/*

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,6 @@ test/usage/*
 model_cache/*
 sanitized_file/*
 src/doc_redaction.egg-info/*
-docker-compose_llama_long_context_dual_gpu.yml
+docker_compose/*
 **/*.quarto_ipynb
-skills/Example agent skills use prompt local.txt
+skills/example_prompts/*

--- a/docker-compose_llama_long_context.yml
+++ b/docker-compose_llama_long_context.yml
@@ -34,7 +34,7 @@ services:
       - --fit
       - "off"
       - --temp
-      - "1.0"
+      - "0.7"
       - --top-k
       - "20"
       - --top-p
@@ -44,7 +44,7 @@ services:
       - --frequency-penalty
       - "1"
       - --presence-penalty
-      - "1.5"
+      - "0.0"
       - --chat-template-kwargs
       - "{\"preserve_thinking\": true}"
       - --host

--- a/docker-compose_vllm.yml
+++ b/docker-compose_vllm.yml
@@ -17,14 +17,13 @@ services:
     shm_size: '8gb'
     command: |
       --model QuantTrio/Qwen3.5-9B-AWQ
-      --gpu-memory-utilization 0.925
+      --gpu-memory-utilization 0.926
       --tensor-parallel-size 1
       --max-num-seqs 1
       --reasoning-parser qwen3
       --max-model-len 16384
       --max-num-batched-tokens 2048
-
-    # --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
+      --speculative-config '{"method":"mtp","num_speculative_tokens":3}'
     
     deploy:
       resources:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "doc_redaction"
-version = "2.2.6"
+version = "2.2.7"
 description = "Redact PDF/image-based documents, Word, or CSV/XLSX files using a Gradio-based GUI interface"
 readme = "README_PYPI.md"
 authors = [

--- a/tools/config.py
+++ b/tools/config.py
@@ -2177,6 +2177,20 @@ MERGE_SMALL_REDACTIONS_MIN_Y_OVERLAP_RATIO = max(
     0.0, min(1.0, _merge_small_redactions_min_y_overlap_ratio)
 )
 
+# Height of the PyMuPDF text-removal strip (add_redact_annot) as a fraction of the redaction
+# bbox height, centered vertically. Lower values reduce adjacent-line text removal in tight
+# layouts; too low may leave selectable text. Ignored for whole-page / very tall boxes.
+try:
+    _redact_text_strip_height_fraction = float(
+        get_or_create_env_var("REDACT_TEXT_STRIP_HEIGHT_FRACTION", "0.6").strip()
+        or "0.6"
+    )
+except ValueError:
+    _redact_text_strip_height_fraction = 0.6
+REDACT_TEXT_STRIP_HEIGHT_FRACTION = max(
+    1e-6, min(1.0, _redact_text_strip_height_fraction)
+)
+
 # When True, use Polars for review DataFrame coordinate scaling and CSV write in apply_redactions_to_review_df_and_files (faster for large annotation sets).
 USE_POLARS_FOR_REVIEW = convert_string_to_boolean(
     get_or_create_env_var("USE_POLARS_FOR_REVIEW", "True")

--- a/tools/file_redaction.py
+++ b/tools/file_redaction.py
@@ -91,6 +91,7 @@ from tools.config import (
     PADDLE_MAX_WORKERS,
     PAGE_BREAK_VALUE,
     PRIORITISE_SSO_OVER_AWS_ENV_ACCESS_KEYS,
+    REDACT_TEXT_STRIP_HEIGHT_FRACTION,
     RETURN_PDF_FOR_REVIEW,
     RETURN_REDACTED_PDF,
     RUN_AWS_FUNCTIONS,
@@ -4768,6 +4769,65 @@ def define_box_colour(
     return out_colour
 
 
+# Bbox height ≥ this fraction of page height uses a near-full-height text strip (whole blocks / tables).
+_TEXT_REDACT_STRIP_LARGE_BOX_PAGE_FRACTION = 0.23
+
+
+def _text_overlap_redact_rect(
+    pymupdf_page: Page,
+    pymupdf_rect: Rect,
+    img_annotation_box: dict,
+) -> Rect:
+    """
+    Rectangle for add_redact_annot text removal: centered strip scaled by bbox height,
+    with guards for whole-page and other tall boxes.
+    """
+    x1, y1, x2, y2 = (
+        float(pymupdf_rect[0]),
+        float(pymupdf_rect[1]),
+        float(pymupdf_rect[2]),
+        float(pymupdf_rect[3]),
+    )
+    box_h = max(0.0, y2 - y1)
+    page_h = float(pymupdf_page.rect.height)
+    label = (img_annotation_box.get("label") or "").strip()
+
+    hx1, hx2 = x1 + 2, x2 - 2
+    if hx1 >= hx2:
+        hx1, hx2 = x1, x2
+
+    use_near_full_height = label == "Whole page" or (
+        page_h > 0 and box_h >= _TEXT_REDACT_STRIP_LARGE_BOX_PAGE_FRACTION * page_h
+    )
+
+    if use_near_full_height or box_h <= 0:
+        redact_bottom_y = y1 + 2
+        redact_top_y = y2 - 2
+        if (redact_top_y - redact_bottom_y) < 1:
+            middle_y = (y1 + y2) / 2
+            redact_bottom_y = middle_y - 1
+            redact_top_y = middle_y + 1
+        return Rect(hx1, redact_bottom_y, hx2, redact_top_y)
+
+    y_mid = (y1 + y2) / 2
+    strip_h = box_h * REDACT_TEXT_STRIP_HEIGHT_FRACTION
+    strip_h = max(strip_h, 0.5)
+    strip_h = min(strip_h, box_h)
+
+    if strip_h < 1.0:
+        redact_bottom_y = y_mid - 1
+        redact_top_y = y_mid + 1
+    else:
+        redact_bottom_y = max(y1, y_mid - strip_h / 2)
+        redact_top_y = min(y2, y_mid + strip_h / 2)
+
+    if redact_top_y <= redact_bottom_y:
+        redact_bottom_y = y_mid - 1
+        redact_top_y = y_mid + 1
+
+    return Rect(hx1, redact_bottom_y, hx2, redact_top_y)
+
+
 def redact_single_box(
     pymupdf_page: Page,
     pymupdf_rect: Rect,
@@ -4802,24 +4862,17 @@ def redact_single_box(
     pymupdf_x2 = pymupdf_rect[2]
     pymupdf_y2 = pymupdf_rect[3]
 
+    img_annotation_box["text"] = img_annotation_box.get("text") or ""
+    img_annotation_box["label"] = img_annotation_box.get("label") or "Redaction"
+
     # Full size redaction box for covering all the text of a word
     full_size_redaction_box = Rect(
         pymupdf_x1 - 1, pymupdf_y1 - 1, pymupdf_x2 + 1, pymupdf_y2 + 1
     )
 
-    # Calculate tiny height redaction box so that it doesn't delete text from adjacent lines
-    redact_bottom_y = pymupdf_y1 + 2
-    redact_top_y = pymupdf_y2 - 2
-
-    # Calculate the middle y value and set a small height if default values are too close together
-    if (redact_top_y - redact_bottom_y) < 1:
-        middle_y = (pymupdf_y1 + pymupdf_y2) / 2
-        redact_bottom_y = middle_y - 1
-        redact_top_y = middle_y + 1
-
-    rect_small_pixel_height = Rect(
-        pymupdf_x1 + 2, redact_bottom_y, pymupdf_x2 - 2, redact_top_y
-    )  # Slightly smaller than outside box
+    rect_small_pixel_height = _text_overlap_redact_rect(
+        pymupdf_page, pymupdf_rect, img_annotation_box
+    )
 
     # Review PDF (..._redactions_for_review.pdf): always use custom colours
     review_colour = define_box_colour(True, img_annotation_box, CUSTOM_BOX_COLOUR)
@@ -4827,9 +4880,6 @@ def redact_single_box(
     output_colour = define_box_colour(
         custom_colours, img_annotation_box, CUSTOM_BOX_COLOUR
     )
-
-    img_annotation_box["text"] = img_annotation_box.get("text") or ""
-    img_annotation_box["label"] = img_annotation_box.get("label") or "Redaction"
 
     # Create a copy of the page for final redaction if needed
     applied_redaction_page = None


### PR DESCRIPTION
Character height overlap for removing text on page with pymupdf is now adjustable. Minor changes to Docker compose files for optimised parameters and VLLM